### PR TITLE
fix rust-analyzer extension id

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,4 +19,4 @@ ports:
 vscode:
   extensions:
     # "The" Rust extension for VSCode
-    - matklad.rust-analyzer
+    - rust-lang.rust-analyzer


### PR DESCRIPTION
fix rust-analyzer extension id